### PR TITLE
#32126 Metalama.Framework.Extensions renamed to Metalama.Extensions.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -62,7 +62,7 @@ object DebugBuild : BuildType({
 
     dependencies {
 
-        snapshot(AbsoluteId("Metalama_MetalamaFrameworkExtensions_DebugBuild")) {
+        snapshot(AbsoluteId("Metalama_MetalamaExtensions_DebugBuild")) {
                      onDependencyFailure = FailureAction.FAIL_TO_START
                 }
 
@@ -113,7 +113,7 @@ object PublicBuild : BuildType({
 
     dependencies {
 
-        snapshot(AbsoluteId("Metalama_MetalamaFrameworkExtensions_PublicBuild")) {
+        snapshot(AbsoluteId("Metalama_MetalamaExtensions_PublicBuild")) {
                      onDependencyFailure = FailureAction.FAIL_TO_START
                 }
 
@@ -159,7 +159,7 @@ object PublicDeployment : BuildType({
 
     dependencies {
 
-        snapshot(AbsoluteId("Metalama_MetalamaFrameworkExtensions_PublicDeployment")) {
+        snapshot(AbsoluteId("Metalama_MetalamaExtensions_PublicDeployment")) {
                      onDependencyFailure = FailureAction.FAIL_TO_START
                 }
 

--- a/code/Metalama.Documentation.Consolidated/Metalama.Documentation.Consolidated.csproj
+++ b/code/Metalama.Documentation.Consolidated/Metalama.Documentation.Consolidated.csproj
@@ -16,8 +16,8 @@
 		<PackageReference Include="Metalama.Framework.Introspection" Version="$(MetalamaVersion)" />
 		<PackageReference Include="Metalama.Framework.Workspaces" Version="$(MetalamaVersion)" />
 		<PackageReference Include="Metalama.LinqPad" Version="$(MetalamaVersion)" />
-		<PackageReference Include="Metalama.Framework.DependencyInjection" Version="$(MetalamaFrameworkExtensionsVersion)" />
-		<PackageReference Include="Metalama.Framework.DependencyInjection.ServiceLocator" Version="$(MetalamaFrameworkExtensionsVersion)" />
+		<PackageReference Include="Metalama.Extensions.DependencyInjection" Version="$(MetalamaExtensionsVersion)" />
+		<PackageReference Include="Metalama.Extensions.DependencyInjection.ServiceLocator" Version="$(MetalamaExtensionsVersion)" />
 		<PackageReference Include="Metalama.Compiler" Version="$(MetalamaCompilerVersion)" />
 	</ItemGroup>
 

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/LogServiceLocator.Additional.cs
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/LogServiceLocator.Additional.cs
@@ -1,4 +1,4 @@
-using Metalama.Framework.DependencyInjection.ServiceLocator;
+using Metalama.Extensions.DependencyInjection.ServiceLocator;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/LogServiceLocator.Aspect.cs
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/LogServiceLocator.Aspect.cs
@@ -1,5 +1,5 @@
 using Metalama.Framework.Aspects;
-using Metalama.Framework.DependencyInjection;
+using Metalama.Extensions.DependencyInjection;
 
 #pragma warning disable CS0649, CS8618
 

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/LogServiceLocator.t.cs
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/LogServiceLocator.t.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Metalama.Framework.DependencyInjection.ServiceLocator;
+using Metalama.Extensions.DependencyInjection.ServiceLocator;
 
 namespace Doc.LogServiceLocator
 {

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/Metalama.Documentation.SampleCode.DependencyInjection.SerrviceLocator.csproj
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection.ServiceLocator/Metalama.Documentation.SampleCode.DependencyInjection.SerrviceLocator.csproj
@@ -19,7 +19,7 @@
 		</PackageReference>
 
 		<PackageReference Include="Metalama.Framework" Version="$(MetalamaVersion)" />
-		<PackageReference Include="Metalama.Framework.DependencyInjection.ServiceLocator" Version="$(MetalamaFrameworkExtensionsVersion)" />
+		<PackageReference Include="Metalama.Extensions.DependencyInjection.ServiceLocator" Version="$(MetalamaExtensionsVersion)" />
 		<PackageReference Include="Metalama.TestFramework" Version="$(MetalamaVersion)" />
 	</ItemGroup>
 </Project>

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection/LogCustomFramework.Aspect.cs
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection/LogCustomFramework.Aspect.cs
@@ -1,7 +1,7 @@
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
-using Metalama.Framework.DependencyInjection;
-using Metalama.Framework.DependencyInjection.Implementation;
+using Metalama.Extensions.DependencyInjection;
+using Metalama.Extensions.DependencyInjection.Implementation;
 using Metalama.Framework.Fabrics;
 using Microsoft.Extensions.Logging;
 

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection/LogDefaultFramework.Aspect.cs
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection/LogDefaultFramework.Aspect.cs
@@ -1,5 +1,5 @@
 using Metalama.Framework.Aspects;
-using Metalama.Framework.DependencyInjection;
+using Metalama.Extensions.DependencyInjection;
 
 #pragma warning disable CS0649, CS8618
 

--- a/code/Metalama.Documentation.SampleCode.DependencyInjection/Metalama.Documentation.SampleCode.DependencyInjection.csproj
+++ b/code/Metalama.Documentation.SampleCode.DependencyInjection/Metalama.Documentation.SampleCode.DependencyInjection.csproj
@@ -21,7 +21,7 @@
 		</PackageReference>
 
 		<PackageReference Include="Metalama.Framework" Version="$(MetalamaVersion)" />
-		<PackageReference Include="Metalama.Framework.DependencyInjection" Version="$(MetalamaFrameworkExtensionsVersion)" />
+		<PackageReference Include="Metalama.Extensions.DependencyInjection" Version="$(MetalamaExtensionsVersion)" />
 		<PackageReference Include="Metalama.TestFramework" Version="$(MetalamaVersion)" />
 	</ItemGroup>
 

--- a/conceptual/Aspects/advising/introducing-constructor-parameters.md
+++ b/conceptual/Aspects/advising/introducing-constructor-parameters.md
@@ -4,7 +4,7 @@ uid: introducing-constructor-parameters
 
 # Introducing Constructor Parameters
 
-Most of the times, when an aspects needs to introduce a constructor to a parameter, it is because it needs to pull a dependency from a dependency injection framework. In this situation, it is recommended to use the `Metalama.Framework.DependencyInjection` framework described in <xref:dependency-injection>.
+Most of the times, when an aspects needs to introduce a constructor to a parameter, it is because it needs to pull a dependency from a dependency injection framework. In this situation, it is recommended to use the `Metalama.Extensions.DependencyInjection` framework described in <xref:dependency-injection>.
 
 Implementations of dependency injection frameworks typically introduce parameters using the method described here.
 

--- a/conceptual/Aspects/dependency-injection.md
+++ b/conceptual/Aspects/dependency-injection.md
@@ -10,29 +10,29 @@ However, the code pattern that must be implemented to pull any dependency depend
 
 In some cases, you as the author of the aspect do not know which dependency injection framework will be used for the classes to which your aspect is applied.
 
-Enter the <xref:Metalama.Framework.DependencyInjection> project. Thanks to this namespace, your aspect can consume and pull a dependency with a single custom attribute. The code pattern to pull the dependency is implemented by the implementation of the <xref:Metalama.Framework.DependencyInjection.Implementation.IDependencyInjectionFramework> interface, which is chosen by the _user_ project. 
+Enter the <xref:Metalama.Extensions.DependencyInjection> project. Thanks to this namespace, your aspect can consume and pull a dependency with a single custom attribute. The code pattern to pull the dependency is implemented by the implementation of the <xref:Metalama.Extensions.DependencyInjection.Implementation.IDependencyInjectionFramework> interface, which is chosen by the _user_ project. 
 
-The <xref:Metalama.Framework.DependencyInjection> namespace is an open source hosted on [GitHub](https://github.com/postsharp/Metalama.Framework.Extensions). It currently has implementations for the following dependency injection framework:
-* <xref:Metalama.Framework.DependencyInjection.Implementation.DefaultDependencyInjectionFramework> implements the default .NET Core pattern  (see `Microsoft.Extensions.DependencyInjection` ).
-* <xref:Metalama.Framework.DependencyInjection.ServiceLocator.ServiceLocatorDependencyInjectionFramework> can be used by classes or projects that are not instantiated by a dependency injection framework thanks a simple _service locator_ pattern.
+The <xref:Metalama.Extensions.DependencyInjection> namespace is an open source hosted on [GitHub](https://github.com/postsharp/Metalama.Framework.Extensions). It currently has implementations for the following dependency injection framework:
+* <xref:Metalama.Extensions.DependencyInjection.Implementation.DefaultDependencyInjectionFramework> implements the default .NET Core pattern  (see `Microsoft.Extensions.DependencyInjection` ).
+* <xref:Metalama.Extensions.DependencyInjection.ServiceLocator.ServiceLocatorDependencyInjectionFramework> can be used by classes or projects that are not instantiated by a dependency injection framework thanks a simple _service locator_ pattern.
 
-The <xref:Metalama.Framework.DependencyInjection> project is designed to make it easy to implement other dependency injection frameworks.
+The <xref:Metalama.Extensions.DependencyInjection> project is designed to make it easy to implement other dependency injection frameworks.
 
 
 ## Consuming dependencies from your aspect
 
 To consume a dependency from an aspect:
 
-1. Add the `Metalama.Framework.DependencyInjection` package to your project.
+1. Add the `Metalama.Extensions.DependencyInjection` package to your project.
 2. Add a field or automatic property of the desired type in your aspect class.
-3. Annotate this field or property with the <xref:Metalama.Framework.DependencyInjection.IntroduceDependencyAttribute> custom attribute. The following attribute properties are available:
-  * <xref:Metalama.Framework.DependencyInjection.IntroduceDependencyAttribute.IsLazy> resolves the dependency upon first use, instead of upon initialization, and
-  * <xref:Metalama.Framework.DependencyInjection.IntroduceDependencyAttribute.IsRequired> throws an exception if the dependency is not available.
+3. Annotate this field or property with the <xref:Metalama.Extensions.DependencyInjection.IntroduceDependencyAttribute> custom attribute. The following attribute properties are available:
+  * <xref:Metalama.Extensions.DependencyInjection.IntroduceDependencyAttribute.IsLazy> resolves the dependency upon first use, instead of upon initialization, and
+  * <xref:Metalama.Extensions.DependencyInjection.IntroduceDependencyAttribute.IsRequired> throws an exception if the dependency is not available.
 4. Use this field or property from any template member of your aspect.
 
 ### Example: default dependency injection patterns
 
-The following example uses the `Microsoft.Extensions.Hosting`, typical to .NET Core applications, to build an application and inject services. The `Program.Main` method builds the host, which then instantiates our `Worker` class. We add a `[Log]` aspect to this class. The `Log` aspect class has a field of type `IMessageWriter`, marked with the <xref:Metalama.Framework.DependencyInjection.IntroduceDependencyAttribute> custom attribute. As you can see in the transformed code, this field is introduced into the `Worker` class and pulled from the constructor.
+The following example uses the `Microsoft.Extensions.Hosting`, typical to .NET Core applications, to build an application and inject services. The `Program.Main` method builds the host, which then instantiates our `Worker` class. We add a `[Log]` aspect to this class. The `Log` aspect class has a field of type `IMessageWriter`, marked with the <xref:Metalama.Extensions.DependencyInjection.IntroduceDependencyAttribute> custom attribute. As you can see in the transformed code, this field is introduced into the `Worker` class and pulled from the constructor.
 
 [!include[Dependency Injection](../../code/Metalama.Documentation.SampleCode.DependencyInjection/LogDefaultFramework.cs)]
 
@@ -47,35 +47,35 @@ What follows is the same example as the previous one, but using the `ServiceLoca
 
 By default, Metalama generates code for the default .NET dependency injection framework implemented in the ``Microsoft.Extensions.DependencyInjection`` namespace (also called the .NET Core dependency injection framework).
 
-If you want to select a different framework for a project, it is generally sufficient to add a reference to the package implementing this dependency framework i.e. for instance `Metalama.Framework.DependencyInjection.ServiceLocator`. These packages generally include a <xref:Metalama.Framework.Fabrics.TransitiveProjectFabric> that register themselves. This works well when there is a single dependency injection framework in the project.
+If you want to select a different framework for a project, it is generally sufficient to add a reference to the package implementing this dependency framework i.e. for instance `Metalama.Extensions.DependencyInjection.ServiceLocator`. These packages generally include a <xref:Metalama.Framework.Fabrics.TransitiveProjectFabric> that register themselves. This works well when there is a single dependency injection framework in the project.
 
-When there are several dependency injection frameworks in a project, Metalama will call the <xref:Metalama.Framework.DependencyInjection.DependencyInjectionOptions.Selector?text=DependencyInjectionOptions.Selector> delegate. Its default implementation is to return the first eligible framework in the input list, i.e. the topmost in the <xref:Metalama.Framework.DependencyInjection.DependencyInjectionOptions.RegisteredFrameworks> list. 
+When there are several dependency injection frameworks in a project, Metalama will call the <xref:Metalama.Extensions.DependencyInjection.DependencyInjectionOptions.Selector?text=DependencyInjectionOptions.Selector> delegate. Its default implementation is to return the first eligible framework in the input list, i.e. the topmost in the <xref:Metalama.Extensions.DependencyInjection.DependencyInjectionOptions.RegisteredFrameworks> list. 
 
 To customize the selection strategy of the dependency injection framework for a specific aspect and dependency:
 
 1. Add a <xref:Metalama.Framework.Fabrics.ProjectFabric> to your project as described in <xref:fabrics-configuring>.
-2. From the <xref:Metalama.Framework.Fabrics.ProjectFabric.AmendProject*> method, call the <xref:Metalama.Framework.DependencyInjection.DependencyInjectionExtensions.DependencyInjectionOptions*?text=amender.Project.DependencyInjectionOptions()> method to access the options.
-3. Set the <xref:Metalama.Framework.DependencyInjection.DependencyInjectionOptions.Selector?text=DependencyInjectionOptions.Selector> property.
+2. From the <xref:Metalama.Framework.Fabrics.ProjectFabric.AmendProject*> method, call the <xref:Metalama.Extensions.DependencyInjection.DependencyInjectionExtensions.DependencyInjectionOptions*?text=amender.Project.DependencyInjectionOptions()> method to access the options.
+3. Set the <xref:Metalama.Extensions.DependencyInjection.DependencyInjectionOptions.Selector?text=DependencyInjectionOptions.Selector> property.
 
  
  ## Implementing an adaptor for a new dependency injection framework
 
  If you need to support a dependency injection framework or pattern for which no ready-made implementation exists, you can implement an adapter yourself.
 
- See [Metalama.Framework.DependencyInjection.ServiceLocator on GitHub](https://github.com/postsharp/Metalama.Framework.Extensions/tree/master/src/Metalama.Framework.DependencyInjection.ServiceLocator) for a working example.
+ See [Metalama.Extensions.DependencyInjection.ServiceLocator on GitHub](https://github.com/postsharp/Metalama.Framework.Extensions/tree/master/src/Metalama.Extensions.DependencyInjection.ServiceLocator) for a working example.
 
  The steps are the following:
 
 1. Create a class library project that targets `netstandard2.0`.
-2. Add a reference to the `Metalama.Framework.DependencyInjection` package.
-3. Implement the <xref:Metalama.Framework.DependencyInjection.Implementation.IDependencyInjectionFramework> interface in a new public class. It is easier to start from the <xref:Metalama.Framework.DependencyInjection.Implementation.DefaultDependencyInjectionFramework> class. In this case, you will also need to override the <xref:Metalama.Framework.DependencyInjection.Implementation.DefaultDependencyInjectionStrategy> class. See the source code and the class documentation for details.
-4. Optionally create a <xref:Metalama.Framework.Fabrics.TransitiveProjectFabric> that registers the framework in <xref:Metalama.Framework.DependencyInjection.DependencyInjectionExtensions.DependencyInjectionOptions*?text=amender.Project.DependencyInjectionOptions()> using the <xref:Metalama.Framework.DependencyInjection.DependencyInjectionOptions.RegisterFramework*> method.
+2. Add a reference to the `Metalama.Extensions.DependencyInjection` package.
+3. Implement the <xref:Metalama.Extensions.DependencyInjection.Implementation.IDependencyInjectionFramework> interface in a new public class. It is easier to start from the <xref:Metalama.Extensions.DependencyInjection.Implementation.DefaultDependencyInjectionFramework> class. In this case, you will also need to override the <xref:Metalama.Extensions.DependencyInjection.Implementation.DefaultDependencyInjectionStrategy> class. See the source code and the class documentation for details.
+4. Optionally create a <xref:Metalama.Framework.Fabrics.TransitiveProjectFabric> that registers the framework in <xref:Metalama.Extensions.DependencyInjection.DependencyInjectionExtensions.DependencyInjectionOptions*?text=amender.Project.DependencyInjectionOptions()> using the <xref:Metalama.Extensions.DependencyInjection.DependencyInjectionOptions.RegisterFramework*> method.
 
 ### Example
 
 The following example shows how to implement the right code generation pattern for the `ILogger` service under .NET Core. Unlike normal services which require a parameter of the same type of the constructor, the `ILogger` service requires a parameter of the generic type `ILogger<T>`, where `T` is the current type, used as a category.
 
-Our implementation of <xref:Metalama.Framework.DependencyInjection.Implementation.IDependencyInjectionFramework> implements the <xref:Metalama.Framework.DependencyInjection.Implementation.DefaultDependencyInjectionFramework.CanHandleDependency*> method, and returns `true` only when the dependency is of type `ILogger`. The only difference in the default implementation strategy is the parameter type.
+Our implementation of <xref:Metalama.Extensions.DependencyInjection.Implementation.IDependencyInjectionFramework> implements the <xref:Metalama.Extensions.DependencyInjection.Implementation.DefaultDependencyInjectionFramework.CanHandleDependency*> method, and returns `true` only when the dependency is of type `ILogger`. The only difference in the default implementation strategy is the parameter type.
 
 
 [!include[Custom Adapter](../../code/Metalama.Documentation.SampleCode.DependencyInjection/LogCustomFramework.cs)]

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -11,8 +11,8 @@
               "Metalama.Framework.Workspaces.dll",
               "Metalama.LinqPad.dll",
               "Metalama.Compiler.Interface.dll",
-              "Metalama.Framework.DependencyInjection.dll",
-              "Metalama.Framework.DependencyInjection.ServiceLocator.dll"
+              "Metalama.Extensions.DependencyInjection.dll",
+              "Metalama.Extensions.DependencyInjection.ServiceLocator.dll"
               ],
           "src": "../code/Metalama.Documentation.Consolidated/bin/Debug/net6.0-windows"
         }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,11 +10,9 @@
 
     <!-- Versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.97-preview</PostSharpEngineeringVersion>
-		<MetalamaVersion>0.5.23-preview</MetalamaVersion>
-        <MetalamaVersion Condition="$(VcsBranch.StartsWith('dev'))">branch:master</MetalamaVersion>
-        <MetalamaFrameworkExtensionsVersion>0.5.50-preview</MetalamaFrameworkExtensionsVersion>
-        <MetalamaFrameworkExtensionsVersion Condition="$(VcsBranch.StartsWith('dev'))">branch:dev</MetalamaFrameworkExtensionsVersion>
+        <PostSharpEngineeringVersion>1.0.98-preview</PostSharpEngineeringVersion>
+        <MetalamaExtensionsVersion>0.5.50-preview</MetalamaExtensionsVersion>
+        <MetalamaExtensionsVersion Condition="$(VcsBranch.StartsWith('dev'))">branch:dev</MetalamaExtensionsVersion>
     </PropertyGroup>
 
     <!-- Import overrides for the local build -->

--- a/eng/src/Program.cs
+++ b/eng/src/Program.cs
@@ -31,7 +31,7 @@ var product = new Product( Dependencies.MetalamaDocumentation )
         docPackageFileName ),
         // Metalama is a a transitive dependency.
     Dependencies = new[] { Dependencies.PostSharpEngineering,
-         Dependencies.MetalamaFrameworkExtensions },
+         Dependencies.MetalamaExtensions },
     AdditionalDirectoriesToClean = new[] { "docfx\\obj", "docfx\\_site" },
 
     // Disable automatic build triggers.

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "major"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.97-preview"
+    "PostSharp.Engineering.Sdk": "1.0.98-preview"
   }
 }


### PR DESCRIPTION
Changes:
* Renamed all references to `Metalama.Framework.Extensions` to `Metalama.Extensions` to ensure working build.