### PR TITLE
#32480 Fixed dependency versions.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,15 +11,15 @@
 
     <!-- Versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.101-preview</PostSharpEngineeringVersion>
-        <MetalamaVersion>branch:master</MetalamaVersion>
-        <MetalamaVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.53-preview</MetalamaVersion>
-        <MetalamaCompilerVersion>branch:master</MetalamaCompilerVersion>
-        <MetalamaCompilerVersion Condition="$(VcsBranch.StartsWith('master'))">4.3.1010-preview</MetalamaCompilerVersion>
-        <MetalamaMigrationVersion>branch:dev</MetalamaMigrationVersion>
-        <MetalamaMigrationVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.79-preview</MetalamaMigrationVersion>
-        <MetalamaExtensionsVersion>branch:dev</MetalamaExtensionsVersion>
-        <MetalamaExtensionsVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.79-preview</MetalamaExtensionsVersion>
+        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
+        <MetalamaVersion>0.5.79-preview</MetalamaVersion>
+        <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
+        <MetalamaCompilerVersion>4.3.1010-preview</MetalamaCompilerVersion>
+        <MetalamaCompilerVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaCompilerVersion>
+        <MetalamaMigrationVersion>0.5.79-preview</MetalamaMigrationVersion>
+        <MetalamaMigrationVersion Condition="$(VcsBranch)!=''">branch:dev</MetalamaMigrationVersion>
+        <MetalamaExtensionsVersion>0.5.79-preview</MetalamaExtensionsVersion>
+        <MetalamaExtensionsVersion Condition="$(VcsBranch)!=''">branch:dev</MetalamaExtensionsVersion>
 		<NuGetCommandLineVersion>6.2.2</NuGetCommandLineVersion>
     </PropertyGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
         <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
         <MetalamaVersion>0.5.79-preview</MetalamaVersion>
         <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
-        <MetalamaCompilerVersion>4.3.1010-preview</MetalamaCompilerVersion>
+        <MetalamaCompilerVersion>4.4.1013-preview</MetalamaCompilerVersion>
         <MetalamaCompilerVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaCompilerVersion>
         <MetalamaMigrationVersion>0.5.79-preview</MetalamaMigrationVersion>
         <MetalamaMigrationVersion Condition="$(VcsBranch)!=''">branch:dev</MetalamaMigrationVersion>

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "major"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.101-preview"
+    "PostSharp.Engineering.Sdk": "1.0.113-preview"
   }
 }


### PR DESCRIPTION
Changes:
* Changed dependencies versions to build with `dotnet build` correctly.
* Updated Engineering for Merge Publisher change.