### PR TITLE
Document the three error-report review choices (#1751)

### DIFF
--- a/content/conceptual/configuration/telemetry.md
+++ b/content/conceptual/configuration/telemetry.md
@@ -48,7 +48,7 @@ Exception and performance reports contain the most detailed information, so by d
 If you don't act on the notification, nothing is sent and the report stays on your machine. Metalama asks you again the next time the same error occurs, at most once an hour, until you choose one of the three actions above. A report you never decide on is deleted along with the rest of the local telemetry data after 30 days.
 
 > [!NOTE]
-> **Never report this error** applies to the error as identified in your current version of Metalama. An error's signature includes the version number, so after upgrading you may be asked again about a seemingly identical error. This is intentional: the new version may behave differently, and if the problem persists we want to know about it.
+> **Never report this error** applies to the error as identified in your current version of Metalama. An error's signature includes the Metalama version number, so after upgrading you may be asked again about a seemingly identical error. This is intentional: the new version may behave differently, and if the problem persists we want to know about it.
 
 This review-first behavior is the default for exception and performance reports. Usage reports have no review step; they're simply enabled or disabled. To stop being asked about exceptions altogether, set that category to _never send_ on the Privacy options page or with the Metalama command-line tools, as described in [Disabling telemetry](#disabling-telemetry).
 

--- a/content/conceptual/configuration/telemetry.md
+++ b/content/conceptual/configuration/telemetry.md
@@ -2,9 +2,9 @@
 uid: telemetry
 level: 200
 summary: "This article explains what data Metalama collects, how to review exception reports before they are sent, and how to disable telemetry per machine or per repository, reset the device ID, and check the current telemetry status."
-keywords: "telemetry, Metalama, disable telemetry, reset device id, license audit, metalama.json, exception report, performance report, privacy, environment variable, telemetry status, news feed, rss"
+keywords: "telemetry, Metalama, disable telemetry, reset device id, license audit, metalama.json, exception report, performance report, privacy, environment variable, telemetry status, news feed, rss, never report this error"
 created-date: 2023-01-23
-modified-date: 2026-06-27
+modified-date: 2026-07-30
 ---
 
 # Telemetry
@@ -38,10 +38,19 @@ In addition to telemetry, if you're using premium components of Metalama (as opp
 Exception and performance reports contain the most detailed information, so by default Metalama lets you review each one before it leaves your machine:
 
 1. When Metalama captures a report, it stores the report locally and, on Windows, shows a notification.
-2. Opening the notification displays the exact, anonymized content that would be uploaded, with a **Report** button to send that individual report.
-3. The same page lets you choose to automatically send all future reports of that category (exceptions or performance problems). Selecting this option switches that category to automatic sending.
+2. Opening the notification displays the full local report next to the exact, anonymized content that would be uploaded, so you can see precisely what the anonymization removes.
+3. You then choose one of three actions:
 
-This review-first behavior is the default for exception and performance reports. Usage reports have no review step; they're simply enabled or disabled. You can change these settings from the Privacy options page or with the Metalama command-line tools, as described in [Disabling telemetry](#disabling-telemetry).
+   - **Report** sends this report, and only this one.
+   - **Report**, with _Automatically report all … in the future_ selected, sends this report and switches that category (exceptions or performance problems) to automatic sending.
+   - **Never report this error** discards the report and stops Metalama from asking about that particular error again. Other errors are still reported to you for review.
+
+If you don't act on the notification, nothing is sent and the report stays on your machine. Metalama asks you again the next time the same error occurs, at most once an hour, until you choose one of the three actions above. A report you never decide on is deleted along with the rest of the local telemetry data after 30 days.
+
+> [!NOTE]
+> **Never report this error** applies to the error as identified in your current version of Metalama. An error's signature includes the version number, so after upgrading you may be asked again about a seemingly identical error. This is intentional: the new version may behave differently, and if the problem persists we want to know about it.
+
+This review-first behavior is the default for exception and performance reports. Usage reports have no review step; they're simply enabled or disabled. To stop being asked about exceptions altogether, set that category to _never send_ on the Privacy options page or with the Metalama command-line tools, as described in [Disabling telemetry](#disabling-telemetry).
 
 ## Disabling telemetry
 


### PR DESCRIPTION
Documentation counterpart of metalama/Metalama#1763, which fixes metalama/Metalama#1751.

The "Reviewing exception and performance reports" section described a two-choice review (**Report**, plus an "automatically report all" checkbox) and implied that a report you ignore is simply never sent. Both are changing in 2026.1.22:

- The review page now offers a third action, **Never report this error**, which discards the report and stops Metalama asking about that particular error, while other errors keep prompting.
- A report you do not act on is no longer forgotten. Metalama asks again the next time the same error occurs, at most once an hour, until you choose one of the three actions.
- The review page shows the full local report next to the scrubbed upload payload, which the section did not mention.

Also added a note that **Never report this error** is scoped to the current Metalama version, because an error's signature includes the version number, so the same error may be raised again after an upgrade. That is intentional and worth setting expectations about.

`modified-date` bumped and one keyword added.

-- Claude for @gfraiteur