### PR TITLE
Document how Metalama restores its compile-time dependencies

### DIFF
--- a/content/conceptual/configuration/msbuild-properties.md
+++ b/content/conceptual/configuration/msbuild-properties.md
@@ -4,7 +4,7 @@ level: 300
 summary: "This article lists MSBuild properties and environment variables, including their types, descriptions, and default values, related to the Metalama compiler."
 keywords: "MSBuild properties, Metalama, environment variables, temporary directory, execution order, transformers, debug transformed code, transformed code files, output path"
 created-date: 2023-03-03
-modified-date: 2026-07-31
+modified-date: 2026-08-02
 ---
 
 # MSBuild properties and environment variables
@@ -40,6 +40,8 @@ All environment variables are imported as MSBuild properties by default.
 | `MetalamaConcurrentBuildEnabled` | Boolean | Specifies whether Metalama can parallelize work across several cores. The default value is `True`. |
 | `MetalamaRoslynIsCompileTimeOnly` | Boolean | Indicates whether types from the `Microsoft.CodeAnalysis` namespaces are considered compile-time-only. The default value is `True`. Set it to `False` if your project uses Roslyn in run-time code. |
 | `MetalamaRootDirectory` | Path | Specifies the directory to which the path of the project is made relative when Metalama computes the identifier of the project. The default value is `$(SolutionDir)`. A relative path keeps the build reproducible, because the identifier is a part of the compilation and a full path would make the compiled assembly depend on the directory into which the repository is cloned. Set this property when a project is built from several solutions located in different directories and the build must be reproducible in all of them. When neither this property nor `$(SolutionDir)` is defined, which is the case when a project is built without a solution, only the file name of the project is used. |
+| `MetalamaAssemblyLocatorHooksDirectory` | Path | Specifies a directory whose `Metalama.AssemblyLocator.Build.props` and `Metalama.AssemblyLocator.Build.targets` files, if they exist, are imported into the internal project that Metalama builds to determine which APIs are available to compile-time code. There is no default value, and no file is imported unless this property is set. See below. |
+| `MetalamaAssemblyLocatorSalt` | String | Specifies an arbitrary value that is included in the cache key of the internal project described below. There is no default value. Change it to any other value to have that project restored and built again instead of its cached result being reused. |
 
 ## MSBuild items
 
@@ -49,6 +51,64 @@ All environment variables are imported as MSBuild properties by default.
 | `MetalamaCompileTimePackage`      | Represents a list of packages accessible from the compile-time code. These packages must explicitly target .NET Standard 2.0 and be included in the project as a `ProjectReference`. By default, only the .NET Standard 2.0 API and the Metalama API are available to compile-time code. |
 | `MetalamaExtensionAssembly`       | Loads an assembly as a Metalama extension at compile time. The assembly must contain types exported via <xref:Metalama.Framework.Engine.Extensibility.ExportExtensionAttribute>. Supports `TargetFramework` (e.g., `net472`, `net8.0`) and `TargetRoslynVersion` (e.g., `4.8`, `4.12`, `5.0`) metadata to specify which build of the extension to load. See <xref:sdk-extensions>. |
 | `MetalamaCompileTimeAssembly`     | Makes an assembly available to compile-time code. Use this when your compile-time code references types from an external assembly that isn't a NuGet package. See <xref:sdk-extensions>. |
+
+## Customizing the internal reference-assembly project
+
+To determine which APIs are available to compile-time code, Metalama generates a project under its temporary
+directory, restores it and builds it. That project references `Microsoft.CodeAnalysis.CSharp` and targets the
+frameworks given by `MetalamaCompileTimeTargetFrameworks`.
+
+The generated project is deliberately isolated from the build customizations of your repository. It inherits your
+`nuget.config`, but it sets `ImportDirectoryBuildProps`, `ImportDirectoryBuildTargets` and
+`ImportDirectoryPackagesProps` to `False`, so your `Directory.Build.props`, `Directory.Build.targets` and
+`Directory.Packages.props` do not apply to it and cannot break it.
+
+That isolation is occasionally too strict, typically in an environment where the restore of this project cannot
+succeed without additional configuration. The `MetalamaAssemblyLocatorHooksDirectory` property names a directory from
+which the generated project imports two optional files:
+
+| File | Where it is imported |
+|------|----------------------|
+| `Metalama.AssemblyLocator.Build.props` | Before the `Microsoft.NET.Sdk` props, so that it can set properties that the SDK reads. |
+| `Metalama.AssemblyLocator.Build.targets` | After the `Microsoft.NET.Sdk` targets, so that it can define targets or hook into the targets of the SDK. |
+
+Each file is imported only if it exists, and neither is required. The two positions are the same as those of
+`Directory.Build.props` and `Directory.Build.targets` in an ordinary SDK-style project.
+
+The following example gives the internal project a NuGet packages folder of its own:
+
+```xml
+<PropertyGroup>
+    <MetalamaAssemblyLocatorHooksDirectory>$(MSBuildThisFileDirectory)metalama-hooks</MetalamaAssemblyLocatorHooksDirectory>
+</PropertyGroup>
+```
+
+`metalama-hooks/Metalama.AssemblyLocator.Build.props`:
+
+```xml
+<Project>
+    <PropertyGroup>
+        <RestorePackagesPath>C:\packages\metalama-compile-time</RestorePackagesPath>
+    </PropertyGroup>
+</Project>
+```
+
+Give the property an absolute path, as in the example above. A relative path is interpreted relative to the generated
+project, which lives under Metalama's temporary directory and not in your repository.
+
+Note that the generated project assigns some properties itself, after the props file is imported and therefore
+overriding it. `RestoreAdditionalProjectSources`, which is set from `MetalamaRestoreSources`, and
+`RestoreIgnoreFailedSources` are among them, as are `TargetFrameworks` and `LangVersion`. Set the NuGet sources of the
+internal project through `MetalamaRestoreSources` or through your `nuget.config` rather than through a hook.
+
+When the property is set, the generated project reports a warning for each file that it imported. Those warnings
+belong to the build of the internal project, whose output Metalama captures, so you see them only when that build
+fails and Metalama reports what it said.
+
+> [!WARNING]
+> The result of this build is cached, and `MetalamaAssemblyLocatorHooksDirectory` is not a part of the cache key.
+> After you change a hook file, the cached result is still used. Assign a new value to the
+> `MetalamaAssemblyLocatorSalt` property, which is a part of the cache key, to have the internal project built again.
 
 ## MSBuild build configurations
 

--- a/content/conceptual/configuration/msbuild-properties.md
+++ b/content/conceptual/configuration/msbuild-properties.md
@@ -40,8 +40,8 @@ All environment variables are imported as MSBuild properties by default.
 | `MetalamaConcurrentBuildEnabled` | Boolean | Specifies whether Metalama can parallelize work across several cores. The default value is `True`. |
 | `MetalamaRoslynIsCompileTimeOnly` | Boolean | Indicates whether types from the `Microsoft.CodeAnalysis` namespaces are considered compile-time-only. The default value is `True`. Set it to `False` if your project uses Roslyn in run-time code. |
 | `MetalamaRootDirectory` | Path | Specifies the directory to which the path of the project is made relative when Metalama computes the identifier of the project. The default value is `$(SolutionDir)`. A relative path keeps the build reproducible, because the identifier is a part of the compilation and a full path would make the compiled assembly depend on the directory into which the repository is cloned. Set this property when a project is built from several solutions located in different directories and the build must be reproducible in all of them. When neither this property nor `$(SolutionDir)` is defined, which is the case when a project is built without a solution, only the file name of the project is used. |
-| `MetalamaAssemblyLocatorHooksDirectory` | Path | Specifies a directory whose `Metalama.AssemblyLocator.Build.props` and `Metalama.AssemblyLocator.Build.targets` files, if they exist, are imported into the internal project that Metalama builds to determine which APIs are available to compile-time code. There is no default value, and no file is imported unless this property is set. See below. |
-| `MetalamaAssemblyLocatorSalt` | String | Specifies an arbitrary value that is included in the cache key of the internal project described below. There is no default value. Change it to any other value to have that project restored and built again instead of its cached result being reused. |
+| `MetalamaAssemblyLocatorHooksDirectory` | Path | Specifies a directory whose `Metalama.AssemblyLocator.Build.props` and `Metalama.AssemblyLocator.Build.targets` files, if they exist, are imported into the internal project that Metalama builds to determine which APIs are available to compile-time code. There is no default value, and no file is imported unless this property is set. See <xref:compile-time-dependencies>. |
+| `MetalamaAssemblyLocatorSalt` | String | Specifies an arbitrary value that is included in the cache key of the project that Metalama builds to resolve the compile-time dependencies. There is no default value. Change it to any other value to have that project restored and built again instead of its cached result being reused. See <xref:compile-time-dependencies>. |
 
 ## MSBuild items
 
@@ -51,64 +51,6 @@ All environment variables are imported as MSBuild properties by default.
 | `MetalamaCompileTimePackage`      | Represents a list of packages accessible from the compile-time code. These packages must explicitly target .NET Standard 2.0 and be included in the project as a `ProjectReference`. By default, only the .NET Standard 2.0 API and the Metalama API are available to compile-time code. |
 | `MetalamaExtensionAssembly`       | Loads an assembly as a Metalama extension at compile time. The assembly must contain types exported via <xref:Metalama.Framework.Engine.Extensibility.ExportExtensionAttribute>. Supports `TargetFramework` (e.g., `net472`, `net8.0`) and `TargetRoslynVersion` (e.g., `4.8`, `4.12`, `5.0`) metadata to specify which build of the extension to load. See <xref:sdk-extensions>. |
 | `MetalamaCompileTimeAssembly`     | Makes an assembly available to compile-time code. Use this when your compile-time code references types from an external assembly that isn't a NuGet package. See <xref:sdk-extensions>. |
-
-## Customizing the internal reference-assembly project
-
-To determine which APIs are available to compile-time code, Metalama generates a project under its temporary
-directory, restores it and builds it. That project references `Microsoft.CodeAnalysis.CSharp` and targets the
-frameworks given by `MetalamaCompileTimeTargetFrameworks`.
-
-The generated project is deliberately isolated from the build customizations of your repository. It inherits your
-`nuget.config`, but it sets `ImportDirectoryBuildProps`, `ImportDirectoryBuildTargets` and
-`ImportDirectoryPackagesProps` to `False`, so your `Directory.Build.props`, `Directory.Build.targets` and
-`Directory.Packages.props` do not apply to it and cannot break it.
-
-That isolation is occasionally too strict, typically in an environment where the restore of this project cannot
-succeed without additional configuration. The `MetalamaAssemblyLocatorHooksDirectory` property names a directory from
-which the generated project imports two optional files:
-
-| File | Where it is imported |
-|------|----------------------|
-| `Metalama.AssemblyLocator.Build.props` | Before the `Microsoft.NET.Sdk` props, so that it can set properties that the SDK reads. |
-| `Metalama.AssemblyLocator.Build.targets` | After the `Microsoft.NET.Sdk` targets, so that it can define targets or hook into the targets of the SDK. |
-
-Each file is imported only if it exists, and neither is required. The two positions are the same as those of
-`Directory.Build.props` and `Directory.Build.targets` in an ordinary SDK-style project.
-
-The following example gives the internal project a NuGet packages folder of its own:
-
-```xml
-<PropertyGroup>
-    <MetalamaAssemblyLocatorHooksDirectory>$(MSBuildThisFileDirectory)metalama-hooks</MetalamaAssemblyLocatorHooksDirectory>
-</PropertyGroup>
-```
-
-`metalama-hooks/Metalama.AssemblyLocator.Build.props`:
-
-```xml
-<Project>
-    <PropertyGroup>
-        <RestorePackagesPath>C:\packages\metalama-compile-time</RestorePackagesPath>
-    </PropertyGroup>
-</Project>
-```
-
-Give the property an absolute path, as in the example above. A relative path is interpreted relative to the generated
-project, which lives under Metalama's temporary directory and not in your repository.
-
-Note that the generated project assigns some properties itself, after the props file is imported and therefore
-overriding it. `RestoreAdditionalProjectSources`, which is set from `MetalamaRestoreSources`, and
-`RestoreIgnoreFailedSources` are among them, as are `TargetFrameworks` and `LangVersion`. Set the NuGet sources of the
-internal project through `MetalamaRestoreSources` or through your `nuget.config` rather than through a hook.
-
-When the property is set, the generated project reports a warning for each file that it imported. Those warnings
-belong to the build of the internal project, whose output Metalama captures, so you see them only when that build
-fails and Metalama reports what it said.
-
-> [!WARNING]
-> The result of this build is cached, and `MetalamaAssemblyLocatorHooksDirectory` is not a part of the cache key.
-> After you change a hook file, the cached result is still used. Assign a new value to the
-> `MetalamaAssemblyLocatorSalt` property, which is a part of the cache key, to have the internal project built again.
 
 ## MSBuild build configurations
 

--- a/content/conceptual/implementation/compile-time-dependencies.md
+++ b/content/conceptual/implementation/compile-time-dependencies.md
@@ -1,0 +1,165 @@
+---
+uid: compile-time-dependencies
+level: 400
+summary: "This article explains how Metalama determines which APIs are available to compile-time code, by restoring and building a small project of its own, and how that result is cached, configured and troubleshot."
+keywords: "compile-time dependencies, reference assemblies, restore, nuget.config, cache, MetalamaCompileTimeTargetFrameworks, MetalamaReferenceAssemblyRestoreTimeout, LAMA0082, LAMA0083"
+created-date: 2026-08-02
+modified-date: 2026-08-02
+---
+
+# Restoring compile-time dependencies
+
+## Why Metalama restores its own dependencies
+
+Compile-time code, such as aspects, templates and fabrics, executes inside the compiler instead of executing in your
+application. It therefore runs against a different set of APIs than your run-time code: the .NET Standard 2.0 API, the
+Roslyn API and the Metalama API.
+
+Metalama needs to know that set precisely. It reports an error when compile-time code uses an API that is not
+available at compile time, and it compiles the compile-time part of your project against exactly these references.
+
+To obtain the set, Metalama generates a small project of its own, restores it, builds it, and collects the reference
+assemblies that the .NET SDK resolved for it. Restoring is the only reliable way to obtain them, because they come
+from NuGet packages and from the targeting packs installed on the machine, neither of which Metalama can enumerate on
+its own.
+
+## When it runs
+
+The restore runs when the compile-time pipeline of a project is initialized and no usable cached result is available.
+This happens during a build and in the IDE alike.
+
+When a usable cached result is available, which is the normal case, nothing is restored, nothing is built, and no
+process is started.
+
+## What is built
+
+The generated project is deliberately minimal, and deliberately isolated from your repository:
+
+* It targets the frameworks listed by the `MetalamaCompileTimeTargetFrameworks` property, which are
+  `netstandard2.0;net8.0;net48` by default. These are the frameworks that can host the compiler. `netstandard2.0` is
+  always required.
+* It references the version of `Microsoft.CodeAnalysis.CSharp` that your version of Metalama is built against, plus
+  whatever you added through the `MetalamaCompileTimePackage` and `MetalamaCompileTimeAssembly` items.
+* It does _not_ import your `Directory.Build.props`, `Directory.Build.targets` or `Directory.Packages.props`. Your
+  build customizations therefore cannot influence it, and cannot break it.
+* It carries a `global.json` requesting the same .NET SDK version as the one that builds your project, when that
+  version is known, so that both builds use the same SDK.
+
+The project is built with `dotnet build`, or with `MSBuild.exe` when your own project is built by `MSBuild.exe`
+without a .NET SDK. The child process does not inherit the .NET SDK and MSBuild environment variables of its parent,
+because a host such as an IDE sets them to its own bundled .NET, which does not necessarily include an SDK.
+
+## Where the result is cached
+
+The generated project and its result are stored under the Metalama temporary directory, in a path of this form:
+
+```text
+<METALAMA_TEMP>/Metalama/AssemblyLocator/<Metalama version>/<hash>
+```
+
+The `<hash>` covers everything that can change the outcome:
+
+* the target frameworks;
+* the additional compile-time packages and assemblies;
+* the version of Roslyn that Metalama targets;
+* the additional NuGet sources given by `MetalamaRestoreSources`;
+* the content of every `nuget.config` file that applies to your project;
+* the `MetalamaAssemblyLocatorSalt` property, whose only purpose is to let you force a new cache entry.
+
+Two projects that agree on all of these share a single cache entry, so a solution normally restores once instead of
+once per project. Concurrent builds are safe: the directory is protected by a system-wide lock, so only one build
+populates it.
+
+A cached result is reused only if it is still complete, which means that the list of reference assemblies exists, that
+every assembly it names is still present on disk, and that the output directory of the generated project still exists.
+When any of these is missing, which typically happens after a NuGet cache has been cleared, the project is restored
+and built again without further notice.
+
+Note that neither the .NET SDK version nor the `MetalamaAssemblyLocatorHooksDirectory` property is a part of the hash.
+
+The directory is deleted by the `metalama cleanup` command once it has been unused for seven days.
+
+## How nuget.config files are merged
+
+The generated project lives outside your repository, so the NuGet configuration of your repository would not apply to
+it. Metalama therefore reproduces that configuration.
+
+It collects every `nuget.config` file from the directory of your project up to the root of the volume, merges them
+into a single file, and writes that file beside the generated project. Files closer to your project are applied last
+and therefore win. Your user-level and machine-level NuGet configuration continues to apply, as it does to any other
+project.
+
+The merge follows these rules:
+
+* An element that has no attribute, such as `<packageSources>`, is merged with the element of the same name.
+* An element that has a `key` attribute, such as `<add key="..." />`, replaces the element with the same name and key
+  accumulated so far, so that the file closest to your project wins.
+* A `<clear />` element discards everything accumulated so far, and is itself preserved, so that the system-wide
+  configuration is cleared as well.
+* Relative paths are rewritten as absolute paths, because the merged file is written in another directory. This
+  applies to the sources of `<packageSources>` and `<fallbackPackageFolders>`, and to the `repositoryPath` and
+  `globalPackagesFolder` keys of the `<config>` section. URLs, absolute paths, and values that reference an undefined
+  environment variable are left unchanged.
+
+The most frequent surprise concerns `packageSourceMapping`. It is merged and applied like any other section, so a
+pattern routing `Microsoft.CodeAnalysis.*` to a private feed also routes the dependency of the generated project,
+which fails when that feed does not carry it. Map these packages to a source that provides them, such as nuget.org.
+
+## Customizing the generated project
+
+When the generated project cannot be restored in your environment without additional configuration, the
+`MetalamaAssemblyLocatorHooksDirectory` property names a directory from which the generated project imports two
+optional files:
+
+| File | Where it is imported |
+|------|----------------------|
+| `Metalama.AssemblyLocator.Build.props` | Before the `Microsoft.NET.Sdk` props, so that it can set properties that the SDK reads. |
+| `Metalama.AssemblyLocator.Build.targets` | After the `Microsoft.NET.Sdk` targets, so that it can define targets or hook into the targets of the SDK. |
+
+Each file is imported only if it exists, and neither is required. The two positions are the same as those of
+`Directory.Build.props` and `Directory.Build.targets` in an ordinary project.
+
+```xml
+<PropertyGroup>
+    <MetalamaAssemblyLocatorHooksDirectory>$(MSBuildThisFileDirectory)metalama-hooks</MetalamaAssemblyLocatorHooksDirectory>
+</PropertyGroup>
+```
+
+Give the property an absolute path, as above. A relative path is interpreted relative to the generated project, which
+is under the Metalama temporary directory and not in your repository.
+
+The generated project assigns some properties itself, after the props file is imported, and a hook therefore cannot
+change them. `RestoreAdditionalProjectSources`, which comes from `MetalamaRestoreSources`, as well as
+`RestoreIgnoreFailedSources`, `TargetFrameworks` and `LangVersion`, are among them. Set the NuGet sources through
+`MetalamaRestoreSources` or through your `nuget.config` instead.
+
+> [!WARNING]
+> The hooks directory is not a part of the cache key, so the cached result is still used after you change a hook file.
+> Assign a new value to the `MetalamaAssemblyLocatorSalt` property to have the project built again.
+
+## When the restore or the build fails
+
+The generated project is built in a separate process, whose output Metalama captures. When that build fails, Metalama
+reports an error of its own and quotes what the build said:
+
+| Diagnostic | Meaning |
+|------------|---------|
+| `LAMA0082` | The build of the generated project completed with an error. The diagnostic quotes the errors that this build reported and, when the cause is recognizable, names it and the way to resolve it. |
+| `LAMA0083` | The build did not complete within its time budget and was stopped. Raise the budget with the `MetalamaReferenceAssemblyRestoreTimeout` property, expressed in milliseconds, whose default value is `120000`. |
+
+Both diagnostics give the path of an MSBuild binary log of the failed build. Open it with the MSBuild Structured Log
+Viewer to see exactly what happened.
+
+These failures are almost always caused by the environment rather than by a defect of Metalama. The most frequent
+causes are:
+
+* a NuGet feed requiring credentials, which the separate process cannot obtain interactively, so that the credentials
+  must be available without user interaction;
+* a `packageSourceMapping` rule routing the dependency of the generated project to a feed that does not carry it;
+* a `global.json` file requesting a .NET SDK version that is not installed;
+* no network access to the configured feeds.
+
+> [!div class="see-also"]
+> <xref:msbuild-properties>
+> <xref:packages>
+> <xref:pipeline>

--- a/content/conceptual/implementation/implementation.md
+++ b/content/conceptual/implementation/implementation.md
@@ -4,12 +4,14 @@ level: 400
 summary: This section covers Metalama's internal implementation details, including the compilation pipeline, aspect composition, serialization, and execution order.
 keywords: "Metalama implementation, compilation pipeline, aspect composition, serialization, execution order, fabrics"
 created-date: 2023-12-11
-modified-date: 2025-11-30
+modified-date: 2026-08-02
 ---
 
 # Under the hood
 
 <xref:packages>
+
+<xref:compile-time-dependencies>
 
 <xref:aspect-serialization>
 

--- a/content/conceptual/toc.yml
+++ b/content/conceptual/toc.yml
@@ -234,6 +234,8 @@ items:
           items:
             - name: NuGet packages
               topicUid: packages
+            - name: Restoring compile-time dependencies
+              topicUid: compile-time-dependencies
             - name: Aspect serialization
               topicUid: aspect-serialization
             - name: Pipeline


### PR DESCRIPTION
Adds a new article, **Restoring compile-time dependencies**, under _Under the hood_
(`content/conceptual/implementation/compile-time-dependencies.md`), and documents two previously undocumented MSBuild
properties.

To know which APIs compile-time code may use, Metalama generates a small project of its own, restores it and builds
it. That process was entirely undocumented, although it is visible to users: it can fail, it caches its result, it
reproduces the NuGet configuration of the repository, and it has properties that configure it.

## The article covers

- **Why** the restore exists: compile-time code runs inside the compiler, against the .NET Standard 2.0, Roslyn and
  Metalama APIs, and that set can only be obtained by restoring, because it comes from NuGet packages and from the
  targeting packs installed on the machine.
- **When** it runs, and that it does nothing when the cached result is usable.
- **What** is built, including the isolation from `Directory.Build.props`, `Directory.Build.targets` and
  `Directory.Packages.props`, and the `global.json` that aligns the .NET SDK with the outer build.
- **How the result is cached and reused**: the path, everything the cache key covers, what makes a cached result
  unusable, that a solution normally restores once rather than once per project, that concurrent builds are safe, and
  that `metalama cleanup` removes the directory after seven days of disuse.
- **How `nuget.config` files are merged**: which files are collected and in which order, the four merge rules
  (attribute-less elements, `key` replacement, `<clear />`, and the rewriting of relative paths), and the fact that the
  user-level and machine-level configuration keeps applying. It also names the `packageSourceMapping` trap, which is
  the most frequent cause of failure in the field.
- **How to customize the generated project** through `MetalamaAssemblyLocatorHooksDirectory`, including the properties
  a hook cannot change and the caching caveat.
- **What happens when it fails**: `LAMA0082` and `LAMA0083`, the binary log they name, and the four causes that
  account for nearly all reports.

## Properties documented

`MetalamaAssemblyLocatorHooksDirectory` and `MetalamaAssemblyLocatorSalt` are added to the MSBuild properties table,
each pointing at the new article. The earlier revision of this pull request explained the hooks directory in a long
section of `msbuild-properties.md`; that section is removed, since the reference table is the wrong place for it.

## Notes

The targets hook never actually worked until metalama/Metalama#1788, fixed in metalama/Metalama#1786. The article
describes the behaviour as of that fix, so the two should be released together.

Every `<xref:>` in the new article was checked against an existing `uid`. The documentation site was not built:
`update-html.ps1` requires `Build.ps1 prepare` to have run in this working tree, which it has not, and the change is
Markdown only.

— Claude for @gfraiteur
