### PR TITLE
Document the memory leak diagnostic and durable references

### DIFF
--- a/content/conceptual/configuration/configuration.md
+++ b/content/conceptual/configuration/configuration.md
@@ -1,10 +1,10 @@
 ---
 uid: configuration
 level: 300
-summary: "This section provides guidance on configuring Metalama, covering topics like telemetry, MSBuild properties, logging, process dumps, performance data collection, unattended build troubleshooting, and NuGet packages."
-keywords: "configuration, troubleshooting, Metalama, telemetry, MSBuild, logging, process dumps, performance, NuGet packages"
+summary: "This section provides guidance on configuring Metalama, covering topics like telemetry, MSBuild properties, logging, process dumps, performance data collection, memory leak diagnostics, unattended build troubleshooting, and NuGet packages."
+keywords: "configuration, troubleshooting, Metalama, telemetry, MSBuild, logging, process dumps, performance, memory leaks, NuGet packages"
 created-date: 2023-03-03
-modified-date: 2025-11-30
+modified-date: 2026-08-04
 ---
 
 # Configuration and troubleshooting
@@ -18,6 +18,7 @@ This section provides guidance on configuring Metalama.
 | <xref:creating-logs> | Shows how to enable logging in Metalama. |
 | <xref:process-dump> | Explains how to instruct Metalama to capture process dumps when exceptions occur. |
 | <xref:profiling> | Shows how to collect performance data for Metalama processes. |
+| <xref:diagnosing-memory-leaks> | Explains how to find out which of your compile-time objects keeps a compilation in memory. |
 | <xref:troubleshooting-unattended-build> | Explains how to deploy diagnostic configurations to a build server. |
 | <xref:packages> | Lists the NuGet packages that constitute Metalama and their dependency graphs. |
 

--- a/content/conceptual/configuration/configuration.md
+++ b/content/conceptual/configuration/configuration.md
@@ -18,8 +18,8 @@ This section provides guidance on configuring Metalama.
 | <xref:creating-logs> | Shows how to enable logging in Metalama. |
 | <xref:process-dump> | Explains how to instruct Metalama to capture process dumps when exceptions occur. |
 | <xref:profiling> | Shows how to collect performance data for Metalama processes. |
-| <xref:diagnosing-memory-leaks> | Explains how to find out which of your compile-time objects keeps a compilation in memory. |
 | <xref:troubleshooting-unattended-build> | Explains how to deploy diagnostic configurations to a build server. |
+| <xref:diagnosing-memory-leaks> | Explains how to find out which of your compile-time objects keeps a compilation in memory. |
 | <xref:packages> | Lists the NuGet packages that constitute Metalama and their dependency graphs. |
 
 > [!div class="see-also"]

--- a/content/conceptual/configuration/diagnosing-memory-leaks.md
+++ b/content/conceptual/configuration/diagnosing-memory-leaks.md
@@ -9,7 +9,7 @@ modified-date: 2026-08-04
 
 # Diagnosing memory leaks caused by compile-time code
 
-If your IDE grows by tens or hundreds of megabytes as you edit a solution that uses Metalama, the cause may be in your own compile-time code. This article explains why that happens and how to find the field responsible.
+An IDE that uses hundreds of megabytes on a large solution is normal, and its memory rising while you work is normal too. What is not normal is memory that **keeps rising for as long as you keep editing, without ever reaching a plateau**, and that a garbage collection does not bring back down. If you observe that on a solution that uses Metalama, the cause may be in your own compile-time code. This article explains why that happens and how to find the field responsible.
 
 ## Why compile-time code can retain memory
 
@@ -23,6 +23,8 @@ Metalama does not run your compile-time code on every keystroke. It runs it once
 * An **inheritable aspect instance**, a **reference validator** and an **annotation** are filed under the path of the document they belong to, and are reused for every later version in which that document did not change.
 
 This is a deliberate design: recompiling your compile-time code between two keystrokes would be far too slow. The consequence is that any object of yours held by one of those results outlives the compilation it was created from. If one of its fields holds a declaration, such as an <xref:Metalama.Framework.Code.INamedType>, that whole version of the project can never be released.
+
+This is what produces the curve without a plateau. One retained version costs what is described above; a field that keeps *accumulating* declarations retains one more version for every edit, so the total grows for as long as the session lasts.
 
 The typical shapes are:
 
@@ -86,13 +88,19 @@ The diagnostic reports the second kind and never the first.
 
 ## Fixing a retention
 
-Call `ToDurable()` on the reference before storing it, and resolve it later with `GetTarget( compilation )` exactly as you would resolve any other reference. Resolving a durable reference costs an identifier lookup, which is why references are not durable by default.
+### Do not store declaration objects
 
-**Declare the requirement in the type rather than in a comment.** A field, property or parameter that keeps a reference beyond a single pipeline run should be typed <xref:Metalama.Framework.Code.IDurableRef`1> instead of <xref:Metalama.Framework.Code.IRef`1>. The conversion can then no longer be forgotten, because the compiler asks for it at every call site, and a reader of your fabric learns the constraint from its signature.
+Never keep an <xref:Metalama.Framework.Code.IDeclaration>, an <xref:Metalama.Framework.Code.INamedType>, an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol` in anything that outlives a single pipeline run: a field of a fabric, a field of an inheritable aspect, a static field, or a variable captured by a lambda you register. Each of them is bound to the compilation it came from and keeps that compilation alive.
 
-The same reasoning applies to anything reachable from a declaration, such as an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol`: none of them may be stored beyond the run.
+The same applies to a plain <xref:Metalama.Framework.Code.IRef`1> obtained from <xref:Metalama.Framework.Code.IDeclaration.ToRef*>. A reference resolves in any compilation version, which makes it the right way to *pass* a declaration between aspects, but it holds the symbol and the compilation behind it, so it is not the right way to *store* one.
 
-Two cases call for something other than a durable reference:
+### Store a durable reference instead
+
+Call `ToDurable()` on the reference before storing it, and resolve it later with `GetTarget( compilation )` exactly as you would resolve any other reference. A durable reference holds only a string identifier. Resolving one costs an identifier lookup, which is why references are not durable by default.
+
+**Type the field <xref:Metalama.Framework.Code.IDurableRef`1>, not <xref:Metalama.Framework.Code.IRef`1>.** The conversion can then no longer be forgotten, because the compiler asks for it at every call site, and a reader of your fabric learns the constraint from its signature rather than from a comment.
+
+### Two cases that call for something else
 
 * A durable reference is backed by a *declaration* identifier, so a constructed generic type such as `Base<int>` resolves back to `Base<T>` and its type arguments are lost silently. Where the value is a type whose shape you do not control, store its full name instead and match on that.
 * When the value has to cross a process or a project boundary, store the <xref:Metalama.Framework.Code.SerializableDeclarationId> returned by `ToSerializableId()` and resolve it with `compilation.Factory.GetDeclarationFromId( id )`.

--- a/content/conceptual/configuration/diagnosing-memory-leaks.md
+++ b/content/conceptual/configuration/diagnosing-memory-leaks.md
@@ -1,8 +1,8 @@
 ---
 uid: diagnosing-memory-leaks
 level: 200
-summary: "This article explains how to find out which of your compile-time objects keeps a compilation in memory, causing the IDE to grow while you edit, using the MetalamaDiagnoseMemoryLeaks MSBuild property."
-keywords: "memory leak, design time, Visual Studio memory, compilation, fabric, inheritable aspect, MetalamaDiagnoseMemoryLeaks, LAMA0085, LAMA0086, durable reference, IDurableRef, ToDurable, ToSerializableId"
+summary: "This article explains how to find out which of your compile-time objects keeps a project snapshot in memory, causing the IDE to grow while you edit, using the MetalamaDiagnoseMemoryLeaks MSBuild property."
+keywords: "memory leak, design time, Visual Studio memory, project snapshot, fabric, inheritable aspect, MetalamaDiagnoseMemoryLeaks, LAMA0085, LAMA0086, durable reference, IDurableRef, ToDurable, ToSerializableId"
 created-date: 2026-08-04
 modified-date: 2026-08-04
 ---
@@ -13,18 +13,18 @@ An IDE that uses hundreds of megabytes on a large solution is normal, and its me
 
 ## Why compile-time code can retain memory
 
-When you build from the command line, the compiler handles one compilation and exits, so nothing that compile-time code keeps in memory matters.
+When you build from the command line, the compiler handles one snapshot of the project and exits, so nothing that compile-time code keeps in memory matters.
 
-The IDE works differently. The Roslyn analysis process stays alive for as long as the solution is open, and it produces a **new compilation on essentially every keystroke**. It releases the previous one as soon as every component that received it does. A single retained compilation keeps alive every syntax tree of the project, the full text of every file, and the symbol tables built from it: tens of megabytes on a medium project.
+The IDE works differently. The Roslyn analysis process stays alive for as long as the solution is open, and it produces a **new snapshot of the project on essentially every keystroke**. It releases the previous one as soon as every component that received it does. A single retained snapshot keeps alive every syntax tree of the project, the full text of every file, and the symbol tables built from it: tens of megabytes on a medium project.
 
 Metalama does not run your compile-time code on every keystroke. It runs it once and reuses the result:
 
 * A **fabric** runs once per pipeline configuration, and everything it registers is reused for every later version of the project, until you change compile-time code.
 * An **inheritable aspect instance**, a **reference validator** and an **annotation** are filed under the path of the document they belong to, and are reused for every later version in which that document did not change.
 
-This is a deliberate design: recompiling your compile-time code between two keystrokes would be far too slow. The consequence is that any object of yours held by one of those results outlives the compilation it was created from. If one of its fields holds a declaration, such as an <xref:Metalama.Framework.Code.INamedType>, that whole version of the project can never be released.
+This is a deliberate design: recompiling your compile-time code between two keystrokes would be far too slow. The consequence is that any object of yours held by one of those results outlives the project snapshot it was created from. If one of its fields holds a declaration, such as an <xref:Metalama.Framework.Code.INamedType>, that whole version of the project can never be released.
 
-This is what produces the curve without a plateau. One retained version costs what is described above; a field that keeps *accumulating* declarations retains one more version for every edit, so the total grows for as long as the session lasts.
+This is what produces the curve without a plateau. One retained snapshot costs what is described above; a field that keeps *accumulating* declarations retains one more snapshot for every edit, so the total grows for as long as the session lasts.
 
 The typical shapes are:
 
@@ -32,7 +32,7 @@ The typical shapes are:
 * a static field of a compile-time class used as a cache;
 * a field of an inheritable aspect marked `[NonCompileTimeSerialized]` that holds a declaration.
 
-## Running the diagnostic
+## Investigating the memory leak
 
 Build the project once from the command line, passing the `MetalamaDiagnoseMemoryLeaks` property:
 
@@ -40,7 +40,7 @@ Build the project once from the command line, passing the `MetalamaDiagnoseMemor
 dotnet build MyProject.csproj -p:MetalamaDiagnoseMemoryLeaks=true
 ```
 
-Metalama then inspects the objects your compile-time code left behind and reports every reference that keeps a compilation alive.
+Metalama then inspects the objects your compile-time code left behind and reports every reference that keeps a project snapshot alive.
 
 This is a one-time investigation, so pass the property on the command line rather than setting it in your project file. The analysis walks the whole object graph of everything your compile-time code registered, which takes time and memory, and it would slow down every build of every developer on the project.
 
@@ -77,12 +77,12 @@ The report file named by `LAMA0086` contains both categories, with the full chai
 
 ## References, durable and otherwise
 
-An <xref:Metalama.Framework.Code.IRef> identifies the same declaration across compilation versions, which is why the API recommends it for passing declarations between aspects. That recommendation concerns a single pipeline run, and it comes with a distinction that matters here.
+An <xref:Metalama.Framework.Code.IRef> identifies the same declaration across project snapshots, which is why the API recommends it for passing declarations between aspects. That recommendation concerns a single pipeline run, and it comes with a distinction that matters here.
 
 A reference is either **durable** or not, as reported by <xref:Metalama.Framework.Code.IRef.IsDurable>:
 
 * A **durable** reference, of type <xref:Metalama.Framework.Code.IDurableRef> or <xref:Metalama.Framework.Code.IDurableRef`1>, stores only a string identifier and holds nothing else. It is safe in an object of any lifetime, and it is what Metalama itself stores in its own long-lived objects.
-* Any **other** reference, such as one returned by <xref:Metalama.Framework.Code.IDeclaration.ToRef*>, holds the symbol and the compilation behind it. It is correct and fast within a run, and it retains a compilation as soon as you store it in something that outlives the run.
+* Any **other** reference, such as one returned by <xref:Metalama.Framework.Code.IDeclaration.ToRef*>, holds the symbol and the project snapshot behind it. It is correct and fast within a run, and it retains a snapshot as soon as you store it in something that outlives the run.
 
 The diagnostic reports the second kind and never the first.
 
@@ -90,9 +90,9 @@ The diagnostic reports the second kind and never the first.
 
 ### Do not store declaration objects
 
-Never keep an <xref:Metalama.Framework.Code.IDeclaration>, an <xref:Metalama.Framework.Code.INamedType>, an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol` in anything that outlives a single pipeline run: a field of a fabric, a field of an inheritable aspect, a static field, or a variable captured by a lambda you register. Each of them is bound to the compilation it came from and keeps that compilation alive.
+Never keep an <xref:Metalama.Framework.Code.IDeclaration>, an <xref:Metalama.Framework.Code.INamedType>, an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol` in anything that outlives a single pipeline run: a field of a fabric, a field of an inheritable aspect, a static field, or a variable captured by a lambda you register. Each of them is bound to the project snapshot it came from and keeps that snapshot alive.
 
-The same applies to a plain <xref:Metalama.Framework.Code.IRef`1> obtained from <xref:Metalama.Framework.Code.IDeclaration.ToRef*>. A reference resolves in any compilation version, which makes it the right way to *pass* a declaration between aspects, but it holds the symbol and the compilation behind it, so it is not the right way to *store* one.
+The same applies to a plain <xref:Metalama.Framework.Code.IRef`1> obtained from <xref:Metalama.Framework.Code.IDeclaration.ToRef*>. A reference resolves in any project snapshot, which makes it the right way to *pass* a declaration between aspects, but it holds the symbol and the snapshot behind it, so it is not the right way to *store* one.
 
 ### Store a durable reference instead
 
@@ -100,7 +100,7 @@ Call `ToDurable()` on the reference before storing it, and resolve it later with
 
 **Type the field <xref:Metalama.Framework.Code.IDurableRef`1>, not <xref:Metalama.Framework.Code.IRef`1>.** The conversion can then no longer be forgotten, because the compiler asks for it at every call site, and a reader of your fabric learns the constraint from its signature rather than from a comment.
 
-### Two cases that call for something else
+### Generic types and cross-project references
 
 * A durable reference is backed by a *declaration* identifier, so a constructed generic type such as `Base<int>` resolves back to `Base<T>` and its type arguments are lost silently. Where the value is a type whose shape you do not control, store its full name instead and match on that.
 * When the value has to cross a process or a project boundary, store the <xref:Metalama.Framework.Code.SerializableDeclarationId> returned by `ToSerializableId()` and resolve it with `compilation.Factory.GetDeclarationFromId( id )`.

--- a/content/conceptual/configuration/diagnosing-memory-leaks.md
+++ b/content/conceptual/configuration/diagnosing-memory-leaks.md
@@ -1,0 +1,109 @@
+---
+uid: diagnosing-memory-leaks
+level: 200
+summary: "This article explains how to find out which of your compile-time objects keeps a compilation in memory, causing the IDE to grow while you edit, using the MetalamaDiagnoseMemoryLeaks MSBuild property."
+keywords: "memory leak, design time, Visual Studio memory, compilation, fabric, inheritable aspect, MetalamaDiagnoseMemoryLeaks, LAMA0085, LAMA0086, ToSerializableId"
+created-date: 2026-08-04
+modified-date: 2026-08-04
+---
+
+# Diagnosing memory leaks caused by compile-time code
+
+If your IDE grows by tens or hundreds of megabytes as you edit a solution that uses Metalama, the cause may be in your own compile-time code. This article explains why that happens and how to find the field responsible.
+
+## Why compile-time code can retain memory
+
+When you build from the command line, the compiler handles one compilation and exits, so nothing that compile-time code keeps in memory matters.
+
+The IDE works differently. The Roslyn analysis process stays alive for as long as the solution is open, and it produces a **new compilation on essentially every keystroke**. It releases the previous one as soon as every component that received it does. A single retained compilation keeps alive every syntax tree of the project, the full text of every file, and the symbol tables built from it: tens of megabytes on a medium project.
+
+Metalama does not run your compile-time code on every keystroke. It runs it once and reuses the result:
+
+* A **fabric** runs once per pipeline configuration, and everything it registers is reused for every later version of the project, until you change compile-time code.
+* An **inheritable aspect instance**, a **reference validator** and an **annotation** are filed under the path of the document they belong to, and are reused for every later version in which that document did not change.
+
+This is a deliberate design: recompiling your compile-time code between two keystrokes would be far too slow. The consequence is that any object of yours held by one of those results outlives the compilation it was created from. If one of its fields holds a declaration, such as an <xref:Metalama.Framework.Code.INamedType>, that whole version of the project can never be released.
+
+The typical shapes are:
+
+* a field of a fabric, or a variable captured by a lambda passed to `Select`, `Where` or `AddAspect`, that accumulates the declarations the query visits;
+* a static field of a compile-time class used as a cache;
+* a field of an inheritable aspect marked `[NonCompileTimeSerialized]` that holds a declaration.
+
+## Running the diagnostic
+
+Build the project once from the command line, passing the `MetalamaDiagnoseMemoryLeaks` property:
+
+```powershell
+dotnet build MyProject.csproj -p:MetalamaDiagnoseMemoryLeaks=true
+```
+
+Metalama then inspects the objects your compile-time code left behind and reports every reference that keeps a compilation alive.
+
+This is a one-time investigation, so pass the property on the command line rather than setting it in your project file. The analysis walks the whole object graph of everything your compile-time code registered, which takes time and memory, and it would slow down every build of every developer on the project.
+
+> [!NOTE]
+> The diagnostic runs during a **normal command-line build**, not in the IDE. Nothing is leaking during that build, because the compiler exits when it finishes. What the build reports is the *shape* of what your code left behind, and that shape is the same in both cases, so a command-line build tells you what an editing session would retain. Running the analysis inside the IDE instead would add its cost to the very process it is meant to protect.
+
+## Reading the report
+
+Each retention in your own code is reported as warning `LAMA0085`, which names the type that holds the reference, the type of the object being held, and the chain of fields that leads from a long-lived object to it:
+
+```text
+warning LAMA0085: The compile-time type 'MyFabric' holds a reference to a 'SourceNamedType',
+which pins the Roslyn compilation. (...) The chain of references is:
+fabric contributor #0 (AspectQuerySource<IDeclaration>) -> _query -> Owner -> _fabricInstance
+-> Driver -> Fabric -> _seen -> _items -> [0].
+```
+
+Read the chain from left to right. It starts at an object that Metalama keeps for the lifetime of the project and ends at the object that cannot be released. The part you can act on is the segment inside your own types, here `_seen`, a `List<INamedType>` field of `MyFabric`.
+
+A summary is reported as warning `LAMA0086`:
+
+```text
+warning LAMA0086: The analysis of the references retained by compile-time code found
+3 retention(s) in code written by the user and 25 retention(s) in Metalama itself. (...)
+The full report is in '%TEMP%\Metalama\FabricRetentionReports\MyProject-net8.0.txt'.
+```
+
+Findings are split in two:
+
+* Retentions in **code written by you**, which is what `LAMA0085` reports and what you can fix.
+* Retentions in **Metalama itself**, which are only counted. Report these to us through [GitHub](https://github.com/metalama/Metalama/issues) if you wish, but they are not something you can act on, and a non-zero count is normal.
+
+The report file named by `LAMA0086` contains both categories, with the full chain for each, formatted one field per line.
+
+## References, durable and otherwise
+
+An <xref:Metalama.Framework.Code.IRef> identifies the same declaration across compilation versions, which is why the API recommends it for passing declarations between aspects. That recommendation concerns a single pipeline run, and it comes with a distinction that matters here.
+
+A reference is either **durable** or not, as reported by <xref:Metalama.Framework.Code.IRef.IsDurable>:
+
+* A **durable** reference stores only a string identifier and holds nothing else. It is safe in an object of any lifetime, and it is what Metalama itself stores in its own long-lived objects. There is currently no public API to create one, so the fix below uses the serializable identifier instead.
+* Any **other** reference, such as one returned by <xref:Metalama.Framework.Code.IDeclaration.ToRef*>, holds the symbol and the compilation behind it. It is correct and fast within a run, and it retains a compilation as soon as you store it in something that outlives the run.
+
+The diagnostic reports the second kind and never the first.
+
+## Fixing a retention
+
+Because you cannot create a durable reference, store the identifier instead and resolve it against the compilation you are given:
+
+* Call `ToSerializableId()` on the declaration or on the reference to obtain a <xref:Metalama.Framework.Code.SerializableDeclarationId>, which is backed by a string and holds nothing else. This is the public equivalent of a durable reference.
+* Call `compilation.Factory.GetDeclarationFromId( id )` to obtain the declaration again.
+
+The same applies to anything reachable from a declaration, such as an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol`.
+
+When you only need to recognize a declaration later rather than to use it, storing its full name or its file path is usually enough and is always safe.
+
+## Limitations
+
+* Compile-time code that behaves differently in the IDE, by testing `IExecutionScenario.IsDesignTime`, is not covered: a command-line build cannot reach that branch.
+* The analysis reads the static fields of your compile-time assemblies, which runs the static constructors of the types that declare them. This is why it is opt-in.
+* A field of an inheritable aspect that is **not** marked `[NonCompileTimeSerialized]` is already checked, more strictly, by the compile-time serializer: it reports an error rather than a warning when the field holds a declaration. This diagnostic covers the fields that the serializer skips.
+
+> [!div class="see-also"]
+> <xref:configuration>
+> <xref:msbuild-properties>
+> <xref:fabrics>
+> <xref:creating-logs>
+> <xref:process-dump>

--- a/content/conceptual/configuration/diagnosing-memory-leaks.md
+++ b/content/conceptual/configuration/diagnosing-memory-leaks.md
@@ -2,7 +2,7 @@
 uid: diagnosing-memory-leaks
 level: 200
 summary: "This article explains how to find out which of your compile-time objects keeps a compilation in memory, causing the IDE to grow while you edit, using the MetalamaDiagnoseMemoryLeaks MSBuild property."
-keywords: "memory leak, design time, Visual Studio memory, compilation, fabric, inheritable aspect, MetalamaDiagnoseMemoryLeaks, LAMA0085, LAMA0086, ToSerializableId"
+keywords: "memory leak, design time, Visual Studio memory, compilation, fabric, inheritable aspect, MetalamaDiagnoseMemoryLeaks, LAMA0085, LAMA0086, durable reference, IDurableRef, ToDurable, ToSerializableId"
 created-date: 2026-08-04
 modified-date: 2026-08-04
 ---
@@ -79,19 +79,23 @@ An <xref:Metalama.Framework.Code.IRef> identifies the same declaration across co
 
 A reference is either **durable** or not, as reported by <xref:Metalama.Framework.Code.IRef.IsDurable>:
 
-* A **durable** reference stores only a string identifier and holds nothing else. It is safe in an object of any lifetime, and it is what Metalama itself stores in its own long-lived objects. There is currently no public API to create one, so the fix below uses the serializable identifier instead.
+* A **durable** reference, of type <xref:Metalama.Framework.Code.IDurableRef> or <xref:Metalama.Framework.Code.IDurableRef`1>, stores only a string identifier and holds nothing else. It is safe in an object of any lifetime, and it is what Metalama itself stores in its own long-lived objects.
 * Any **other** reference, such as one returned by <xref:Metalama.Framework.Code.IDeclaration.ToRef*>, holds the symbol and the compilation behind it. It is correct and fast within a run, and it retains a compilation as soon as you store it in something that outlives the run.
 
 The diagnostic reports the second kind and never the first.
 
 ## Fixing a retention
 
-Because you cannot create a durable reference, store the identifier instead and resolve it against the compilation you are given:
+Call `ToDurable()` on the reference before storing it, and resolve it later with `GetTarget( compilation )` exactly as you would resolve any other reference. Resolving a durable reference costs an identifier lookup, which is why references are not durable by default.
 
-* Call `ToSerializableId()` on the declaration or on the reference to obtain a <xref:Metalama.Framework.Code.SerializableDeclarationId>, which is backed by a string and holds nothing else. This is the public equivalent of a durable reference.
-* Call `compilation.Factory.GetDeclarationFromId( id )` to obtain the declaration again.
+**Declare the requirement in the type rather than in a comment.** A field, property or parameter that keeps a reference beyond a single pipeline run should be typed <xref:Metalama.Framework.Code.IDurableRef`1> instead of <xref:Metalama.Framework.Code.IRef`1>. The conversion can then no longer be forgotten, because the compiler asks for it at every call site, and a reader of your fabric learns the constraint from its signature.
 
-The same applies to anything reachable from a declaration, such as an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol`.
+The same reasoning applies to anything reachable from a declaration, such as an <xref:Metalama.Framework.Code.IType>, a `SemanticModel` or a Roslyn `ISymbol`: none of them may be stored beyond the run.
+
+Two cases call for something other than a durable reference:
+
+* A durable reference is backed by a *declaration* identifier, so a constructed generic type such as `Base<int>` resolves back to `Base<T>` and its type arguments are lost silently. Where the value is a type whose shape you do not control, store its full name instead and match on that.
+* When the value has to cross a process or a project boundary, store the <xref:Metalama.Framework.Code.SerializableDeclarationId> returned by `ToSerializableId()` and resolve it with `compilation.Factory.GetDeclarationFromId( id )`.
 
 When you only need to recognize a declaration later rather than to use it, storing its full name or its file path is usually enough and is always safe.
 

--- a/content/conceptual/configuration/msbuild-properties.md
+++ b/content/conceptual/configuration/msbuild-properties.md
@@ -2,9 +2,9 @@
 uid: msbuild-properties
 level: 300
 summary: "This article lists MSBuild properties and environment variables, including their types, descriptions, and default values, related to the Metalama compiler."
-keywords: "MSBuild properties, Metalama, environment variables, temporary directory, execution order, transformers, debug transformed code, transformed code files, output path"
+keywords: "MSBuild properties, Metalama, environment variables, temporary directory, execution order, transformers, debug transformed code, transformed code files, output path, memory leaks"
 created-date: 2023-03-03
-modified-date: 2026-08-02
+modified-date: 2026-08-04
 ---
 
 # MSBuild properties and environment variables
@@ -42,6 +42,7 @@ All environment variables are imported as MSBuild properties by default.
 | `MetalamaRootDirectory` | Path | Specifies the directory to which the path of the project is made relative when Metalama computes the identifier of the project. The default value is `$(SolutionDir)`. A relative path keeps the build reproducible, because the identifier is a part of the compilation and a full path would make the compiled assembly depend on the directory into which the repository is cloned. Set this property when a project is built from several solutions located in different directories and the build must be reproducible in all of them. When neither this property nor `$(SolutionDir)` is defined, which is the case when a project is built without a solution, only the file name of the project is used. |
 | `MetalamaAssemblyLocatorHooksDirectory` | Path | Specifies a directory whose `Metalama.AssemblyLocator.Build.props` and `Metalama.AssemblyLocator.Build.targets` files, if they exist, are imported into the internal project that Metalama builds to determine which APIs are available to compile-time code. There is no default value, and no file is imported unless this property is set. See <xref:compile-time-dependencies>. |
 | `MetalamaAssemblyLocatorSalt` | String | Specifies an arbitrary value that is included in the cache key of the project that Metalama builds to resolve the compile-time dependencies. There is no default value. Change it to any other value to have that project restored and built again instead of its cached result being reused. See <xref:compile-time-dependencies>. |
+| `MetalamaDiagnoseMemoryLeaks` | Boolean | Indicates whether the objects that your compile-time code leaves behind should be analyzed for references that keep a compilation in memory. The default value is `False`. Pass this property on the command line of a single build while you are investigating a memory leak: the analysis walks a large object graph and is too slow for an ordinary build. See <xref:diagnosing-memory-leaks>. |
 
 ## MSBuild items
 

--- a/content/conceptual/toc.yml
+++ b/content/conceptual/toc.yml
@@ -270,10 +270,10 @@ items:
           topicUid: process-dump
         - name: Capturing performance data
           topicUid: profiling
-        - name: Diagnosing memory leaks
-          topicUid: diagnosing-memory-leaks
         - name: Troubleshooting a build server
           topicUid: troubleshooting-unattended-build
+        - name: Diagnosing memory leaks
+          topicUid: diagnosing-memory-leaks
         - name: Telemetry
           topicUid: telemetry
 

--- a/content/conceptual/toc.yml
+++ b/content/conceptual/toc.yml
@@ -270,6 +270,8 @@ items:
           topicUid: process-dump
         - name: Capturing performance data
           topicUid: profiling
+        - name: Diagnosing memory leaks
+          topicUid: diagnosing-memory-leaks
         - name: Troubleshooting a build server
           topicUid: troubleshooting-unattended-build
         - name: Telemetry


### PR DESCRIPTION
## Summary

Documents the opt-in diagnostic that reports which compile-time objects keep a Roslyn compilation in memory, added in
[metalama/Metalama#1802](https://github.com/metalama/Metalama/issues/1802), and the public durable-reference API added
in [metalama/Metalama#1806](https://github.com/metalama/Metalama/issues/1806).

- **New article** `content/conceptual/configuration/diagnosing-memory-leaks.md`, uid `diagnosing-memory-leaks`, as a
  subtopic of <xref:configuration>. Registered in `content/conceptual/toc.yml` between "Capturing performance data" and
  "Troubleshooting a build server", and added to the child table of the parent page.
- **`msbuild-properties.md`** gains a `MetalamaDiagnoseMemoryLeaks` row.

The article covers why an IDE session accumulates memory that a command-line build never does, which objects of the
user's own code the design-time pipeline keeps across compilations, how to run the diagnostic, how to read `LAMA0085`
and `LAMA0086`, how to fix a retention, and the limitations.

## Points worth a reviewer's attention

- **The property is presented as a one-off command-line argument**, not as something to add to a project file, because
  the analysis walks a large object graph and would slow down every build of every developer on the project.
- **The fix is `ToDurable()`**, with the accompanying advice to type the field `IDurableRef<T>` rather than `IRef<T>` so
  that the compiler asks for the conversion instead of a comment asking the reader. `ToSerializableId()` is positioned
  where it belongs, in the cross-process and cross-project case.
- **The constructed-generic trap is stated**: a durable reference is backed by a *declaration* identifier, so
  `Base<int>` resolves back to `Base<T>` and the type arguments are lost silently.
- **The boundary with the compile-time serializer is stated**, because the two guards are easy to confuse: the
  serializer already rejects a declaration in a serialized field of an externally inheritable aspect, with an error.
  What it cannot see, and what this diagnostic covers, is a field marked `[NonCompileTimeSerialized]`.
- No inline C# code blocks, per the repository convention that every C# example must be a compilable file under
  `code/`. The article uses PowerShell and sample diagnostic output only.

## Ordering

This PR describes `ToDurable()` as public API, which it becomes only with
[metalama/Metalama#1807](https://github.com/metalama/Metalama/pull/1807). Please merge that one first.

## Related

- [metalama/Metalama#1802](https://github.com/metalama/Metalama/issues/1802) - the diagnostic
- [metalama/Metalama#1806](https://github.com/metalama/Metalama/issues/1806) - the public durable-reference API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
